### PR TITLE
lineage: Enable wifi wakeup config option

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -85,4 +85,10 @@
    <!-- Set icon mask to circle -->
    <string name="config_icon_mask" translatable="false">"M50 0A50 50,0,1,1,50 100A50 50,0,1,1,50 0"</string>
 
+    <!-- Controls the WiFi wakeup feature.
+          0 = Not available.
+          1 = Available.
+    -->
+    <integer translatable="false" name="config_wifi_wakeup_available">1</integer>
+
 </resources>


### PR DESCRIPTION
Enables the setting to have wifi turn on automatically
when you're near high quality saved networks.

Change-Id: Id61c3f5c655322e54c015f55b6f389b835c27fe5