### PR TITLE
write_makefiles: fix paths in BUILD_PREBUILT with destination

### DIFF
--- a/build/tools/extract_utils.sh
+++ b/build/tools/extract_utils.sh
@@ -148,7 +148,8 @@ function target_args() {
 #
 function prefix_match() {
     local PREFIX="$1"
-    for FILE in "${PRODUCT_PACKAGES_LIST[@]}"; do
+    for LINE in "${PRODUCT_PACKAGES_LIST[@]}"; do
+        local FILE=$(target_file "$LINE")
         if [[ "$FILE" =~ ^"$PREFIX" ]]; then
             printf '%s\n' "${FILE#$PREFIX}"
         fi


### PR DESCRIPTION
 * proprietary-files.txt entries such as
   "-app/TimeService/TimeService.apk:priv-app/TimeService/TimeService.apk" should
   generate a "LOCAL_SRC_FILES := proprietary/priv-app/TimeService/TimeService.apk"
   in the Makefile definition.
 * However, currently, the prefix_match function is being called on the whole
   PRODUCT_PACKAGES_LIST entry (whole line, including ":"), and therefore,
   TimeService.apk would be included in the APPS list instead of PRIV_APPS.
 * Furthermore, because of the incorrect prefix_match, the generated
   LOCAL_SRC_FILES is "proprietary/app/priv-app/TimeService/TimeService.apk",
   which breaks the build because there is no file at that wrong path.
 * The fix is to make the extract function match up with write_product_packages
   by applying the target_file function on all BUILD_PREBUILT source files.

Change-Id: Ib4859b8854db0f2142bb3f28cce8dd25f7141732
Signed-off-by: Vladimir Oltean <olteanv@gmail.com>