### PR TITLE
build: kernel: Use LLVM_PREBUILTS_VERSION if no version is specified

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -228,8 +228,8 @@ ifeq ($(TARGET_KERNEL_CLANG_COMPILE),true)
         # Find the clang-* directory containing the specified version
         KERNEL_CLANG_VERSION := $(shell find $(ANDROID_BUILD_TOP)/prebuilts/clang/host/$(HOST_OS)-x86/ -name AndroidVersion.txt -exec grep -l $(TARGET_KERNEL_CLANG_VERSION) "{}" \; | sed -e 's|/AndroidVersion.txt$$||g;s|^.*/||g')
     else
-        # Only set the latest version of clang if TARGET_KERNEL_CLANG_VERSION hasn't been set by the device config
-        KERNEL_CLANG_VERSION := $(shell ls -d $(ANDROID_BUILD_TOP)/prebuilts/clang/host/$(HOST_OS)-x86/clang-* | xargs -n 1 basename | tail -1)
+        # Use the default version of clang if TARGET_KERNEL_CLANG_VERSION hasn't been set by the device config
+        KERNEL_CLANG_VERSION := $(LLVM_PREBUILTS_VERSION)
     endif
     TARGET_KERNEL_CLANG_PATH ?= $(ANDROID_BUILD_TOP)/prebuilts/clang/host/$(HOST_OS)-x86/$(KERNEL_CLANG_VERSION)/bin
     ifeq ($(KERNEL_ARCH),arm64)


### PR DESCRIPTION
Some ROMs may want to track Google's master branch, which has Clang 6
and 7 toolchains available, as it gets rid of some hacks in the kernel
source. Unfortunately, with the current default choosing logic, the
latest one would be chosen, which it shouldn't be. Use the variable set
in build/make/core/clang/versions.mk, as that's what was intended.

Change-Id: I607c7f750f62caabee4cdccea67846feb7f632fa
Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>