### PR TITLE
Fix migration from pre-O for AndroidTV devices (2/2)

### DIFF
--- a/overlay/tv/frameworks/base/packages/SettingsProvider/res/values/lineage_defaults.xml
+++ b/overlay/tv/frameworks/base/packages/SettingsProvider/res/values/lineage_defaults.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright (c) 2018, The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources>
+    <string name="def_tv_user_setup_complete" translatable="false">false</string>
+</resources>


### PR DESCRIPTION
Change-Id: I81fb44cb18c081d61cab5743b7a1176e6a8fe422