### PR TITLE
lineage: qcom: Enable TARGET_USES_COLOR_METADATA for msm8937 & msm8953

### DIFF
--- a/build/core/qcom_target.mk
+++ b/build/core/qcom_target.mk
@@ -51,8 +51,8 @@ ifeq ($(BOARD_USES_QCOM_HARDWARE),true)
     # Allow building audio encoders
     TARGET_USES_QCOM_MM_AUDIO := true
 
-    # Enable color metadata for modern UM targets
-    ifneq ($(filter msm8996 msm8998 sdm660,$(TARGET_BOARD_PLATFORM)),)
+    # Enable color metadata for UM platforms
+    ifeq ($(call is-board-platform-in-list, $(UM_3_18_FAMILY) $(UM_4_4_FAMILY)),true)
         TARGET_USES_COLOR_METADATA := true
     endif
 


### PR DESCRIPTION
* This is set in qcom device trees for all UM platforms

Change-Id: I6feb714e725e7cd81a4428d16a89954b796fac70