### PR TITLE
config/common: Organize filesystems tools

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -172,21 +172,16 @@ PRODUCT_PACKAGES += \
     bash \
     bzip2 \
     curl \
-    fsck.ntfs \
     gdbserver \
     htop \
     lib7z \
     libsepol \
     micro_bench \
-    mke2fs \
-    mkfs.ntfs \
-    mount.ntfs \
     oprofiled \
     pigz \
     powertop \
     sqlite3 \
     strace \
-    tune2fs \
     unrar \
     unzip \
     vim \
@@ -205,10 +200,14 @@ PRODUCT_PACKAGES += \
     libhealthd.lineage
 endif
 
-# exFAT tools
+# Filesystems tools
 PRODUCT_PACKAGES += \
     fsck.exfat \
-    mkfs.exfat
+    fsck.ntfs \
+    mke2fs \
+    mkfs.exfat \
+    mkfs.ntfs \
+    mount.ntfs
 
 # Openssh
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
 * Along with it, remove tune2fs as the tool is already part of
   build/target/product/core_minimal.mk. Despite Google did quite
   a big cleanup in master branch, it's still built by default.

Change-Id: I4cf1178c2f99eda5a45de4ba79705093de5cd9bf