### PR TITLE
addonsu: Fix installation on Lineage recovery

### DIFF
--- a/addonsu/mount-system.sh
+++ b/addonsu/mount-system.sh
@@ -19,8 +19,7 @@ if [ "$system_as_root" == "true" ]; then
   else
     block=/dev/block/bootdevice/by-name/system
   fi
-  mkdir -p /system_root
-  if mount -o rw $block /system_root && mount /system_root/system /system; then
+  if mount -o rw $block /system_root && mount /system_root /system; then
     exit 0
   fi
 fi


### PR DESCRIPTION
Commit fd798c51771663dd54b6e24f7b22b70da45e5d0c restored the old TWRP
workaround, which installs addonsu stuff to /system/system for
compatibility reasons.

However, our script currently (and correctly) mounts /system_root/system
to /system, meaning the actual "system" contents are properly presented
at /system. This breaks addonsu installation because of the TWRP workaround.

Now we could just revert the TWRP workaround again and break all users on
such setups, but instead we decided to add yet another workaround to make
the package compatible with both TWRP and Lineage recovery systems.

Change-Id: I7f44a29c49e07e59017d8eba7359e3f8d8b5a4f7