### PR TITLE
tasks: kernel: Honor prebuilt kernel flag

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -77,6 +77,9 @@ TARGET_AUTO_KDIR := $(shell echo $(TARGET_DEVICE_DIR) | sed -e 's/^device/kernel
 ## Externally influenced variables
 # kernel location - optional, defaults to kernel/<vendor>/<device>
 TARGET_KERNEL_SOURCE ?= $(TARGET_AUTO_KDIR)
+ifneq ($(TARGET_PREBUILT_KERNEL),)
+TARGET_KERNEL_SOURCE :=
+endif
 KERNEL_SRC := $(TARGET_KERNEL_SOURCE)
 # kernel configuration - mandatory
 KERNEL_DEFCONFIG := $(TARGET_KERNEL_CONFIG)


### PR DESCRIPTION
For devices that want to use a prebuilt kernel, TARGET_KERNEL_SOURCE
would still be set to TARGET_AUTO_KDIR, meaning the build system would
still try to build the kernel if TARGET_AUTO_KDIR was present.

Setting TARGET_PREBUILT_KERNEL indicates this is not wanted, so don't
attempt to do it.

Change-Id: Ic79b3ac1b9c946fd258ada43dce2b08bb74ea0d9