### PR TITLE
kernel: Correct CROSS_COMPILE_ARM32 toolchain

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -272,7 +272,7 @@ endif
 
 # Needed for CONFIG_COMPAT_VDSO, safe to set for all arm64 builds
 ifeq ($(KERNEL_ARCH),arm64)
-   KERNEL_CROSS_COMPILE += CROSS_COMPILE_ARM32="arm-linux-androideabi-"
+   KERNEL_CROSS_COMPILE += CROSS_COMPILE_ARM32="arm-linux-androidkernel-"
 endif
 
 ccache =


### PR DESCRIPTION
* Missed in the original commit that switched to
  androidkernel toochain

Change-Id: I9b6d2e7216b48d22bcb7eec62c4fd9c05a895d18