### PR TITLE
privapp-permissions: Whitelist CHANGE_OVERLAY_PACKAGES permission

### DIFF
--- a/config/permissions/privapp-permissions-lineage.xml
+++ b/config/permissions/privapp-permissions-lineage.xml
@@ -63,6 +63,7 @@
 
     <privapp-permissions package="org.lineageos.lineageparts">
         <permission name="android.permission.CHANGE_CONFIGURATION"/>
+        <permission name="android.permission.CHANGE_OVERLAY_PACKAGES"/>
         <permission name="android.permission.READ_SEARCH_INDEXABLES"/>
         <permission name="android.permission.WRITE_MEDIA_STORAGE"/>
         <permission name="android.permission.WRITE_SECURE_SETTINGS"/>


### PR DESCRIPTION
 * LineageParts now uses AOSP permission CHANGE_OVERLAY_PACKAGES for styles

Change-Id: Iedf4c5165f2512879bcea7d5d28abe2ff20ca0a5