### PR TITLE
lineage-iosched: restorecon scheduler tuneables before touching them

### DIFF
--- a/prebuilt/common/etc/init/lineage-iosched.rc
+++ b/prebuilt/common/etc/init/lineage-iosched.rc
@@ -14,21 +14,21 @@ on init
     chmod 0220 /dev/bfqio/rt-display/cgroup.event_control
 
 on boot
+    restorecon --recursive /sys/block/mmcblk0/queue
     chown system system /sys/block/mmcblk0/queue/scheduler
     chmod 0664 /sys/block/mmcblk0/queue/scheduler
-    restorecon /sys/block/mmcblk0/queue/scheduler
 
+    restorecon --recursive /sys/block/sda/queue
     chown system system /sys/block/sda/queue/scheduler
     chmod 0664 /sys/block/sda/queue/scheduler
-    restorecon /sys/block/sda/queue/scheduler
 
+    restorecon --recursive /sys/block/sde/queue
     chown system system /sys/block/sde/queue/scheduler
     chmod 0664 /sys/block/sde/queue/scheduler
-    restorecon /sys/block/sde/queue/scheduler
 
+    restorecon --recursive /sys/block/dm-0/queue
     chown system system /sys/block/dm-0/queue/scheduler
     chmod 0664 /sys/block/dm-0/queue/scheduler
-    restorecon /sys/block/dm-0/queue/scheduler
 
 # Configure IO scheduler
 on property:sys.io.scheduler=*
@@ -43,6 +43,12 @@ on property:persist.sys.io.scheduler=*
 
 # Set slice_idle to 0 for CFQ
 on property:sys.io.scheduler=cfq
+    restorecon --recursive /sys/block/mmcblk0/queue
+    restorecon --recursive /sys/block/mmcblk1/queue
+    restorecon --recursive /sys/block/sda/queue
+    restorecon --recursive /sys/block/sde/queue
+    restorecon --recursive /sys/block/dm-0/queue
+
     write /sys/block/mmcblk0/queue/iosched/slice_idle 0
     write /sys/block/mmcblk1/queue/iosched/slice_idle 0
     write /sys/block/sda/queue/iosched/slice_idle 0
@@ -51,6 +57,12 @@ on property:sys.io.scheduler=cfq
 
 # Set slice_idle to 0 for BFQ
 on property:sys.io.scheduler=bfq
+    restorecon --recursive /sys/block/mmcblk0/queue
+    restorecon --recursive /sys/block/mmcblk1/queue
+    restorecon --recursive /sys/block/sda/queue
+    restorecon --recursive /sys/block/sde/queue
+    restorecon --recursive /sys/block/dm-0/queue
+
     write /sys/block/mmcblk0/queue/iosched/slice_idle 0
     write /sys/block/mmcblk1/queue/iosched/slice_idle 0
     write /sys/block/sda/queue/iosched/slice_idle 0


### PR DESCRIPTION
* LineageOS/android_system_sepolicy@0e3235f45d removed open, read,
  and write for init to general sysfs types. As schedulers are
  changed, the related directories gets dynamically torn-down and
  rebuilt, but they lacks proper contexts. We need to make sure the
  context is correct before init can write to these nodes.

Change-Id: Ic6f4567c173799bc56ecccc217040392f73aeaba