### PR TITLE
extract_utils: avoid doing stuff on files that don't exist

### DIFF
--- a/build/tools/extract_utils.sh
+++ b/build/tools/extract_utils.sh
@@ -1064,6 +1064,7 @@ function extract() {
 
             if [ "${FOUND}" = false ]; then
                 printf '    !! file not found in source\n'
+                continue
             fi
         fi
 


### PR DESCRIPTION
* If an apk/jar doesn't exist, the script would still try to deodex it.
* If an xml doesn't exist, the script would still try to "fix" it.
* Take it easier, man, it's not your fault.

Change-Id: I3061fb48b403da5121e3c17dd9ecdb6cd148bf97
Signed-off-by: Vladimir Oltean <olteanv@gmail.com>