### PR TITLE
config: Add Deskclock to power whitelist

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -95,6 +95,10 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     vendor/lineage/config/permissions/lineage-hiddenapi-package-whitelist.xml:system/etc/permissions/lineage-hiddenapi-package-whitelist.xml
 
+# Power whitelist
+PRODUCT_COPY_FILES += \
+    vendor/lineage/config/permissions/lineage-power-whitelist.xml:system/etc/sysconfig/lineage-power-whitelist.xml
+
 # Include Lineage audio files
 include vendor/lineage/config/lineage_audio.mk
 

--- a/config/permissions/lineage-power-whitelist.xml
+++ b/config/permissions/lineage-power-whitelist.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2019 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<config>
+    <allow-in-power-save package="com.android.deskclock" />
+</config>


### PR DESCRIPTION
 * Seems sometimes alarm cannot ring because of doze.

Change-Id: I3a35d2f02de365ea1d3a99ea75e0db9905d482a3