### PR TITLE
prebuilt: backuptool: Drop addond version check on A-only

### DIFF
--- a/prebuilt/common/bin/backuptool.sh
+++ b/prebuilt/common/bin/backuptool.sh
@@ -8,8 +8,6 @@ export SYSDEV="$(readlink -nf "$2")"
 export SYSFS="$3"
 export V=17.1
 
-export ADDOND_VERSION=1
-
 # Scripts in /system/addon.d expect to find backuptool.functions in /tmp
 cp -f /tmp/install/bin/backuptool.functions /tmp
 
@@ -18,18 +16,6 @@ preserve_addon_d() {
   if [ -d $S/addon.d/ ]; then
     mkdir -p /tmp/addon.d/
     cp -a $S/addon.d/* /tmp/addon.d/
-
-    # Discard any scripts that aren't at least our version level
-    for f in /tmp/addon.d/*sh; do
-      SCRIPT_VERSION=$(grep "^# ADDOND_VERSION=" $f | cut -d= -f2)
-      if [ -z "$SCRIPT_VERSION" ]; then
-        SCRIPT_VERSION=1
-      fi
-      if [ $SCRIPT_VERSION -lt $ADDOND_VERSION ]; then
-        rm $f
-      fi
-    done
-
     chmod 755 /tmp/addon.d/*.sh
   fi
 }


### PR DESCRIPTION
 * This check was supposed to check whether the script
   addon.d version was lower than backuptool's

 * Given that the backuptool addon.d version is 1, this
   isn't going to happen ever making this check completely
   unuseful

Change-Id: I2464749b52bf4e8825e0b4ef42500ee7d3bbfa61