### PR TITLE
Revert "lineage: configs: Flatten APEX(s) on official builds"

### DIFF
--- a/config/BoardConfigLineage.mk
+++ b/config/BoardConfigLineage.mk
@@ -1,8 +1,3 @@
-# APEX
-ifneq ($(filter RELEASE NIGHTLY SNAPSHOT EXPERIMENTAL,$(LINEAGE_BUILDTYPE)),)
-    TARGET_FLATTEN_APEX := true
-endif
-
 # Charger
 ifeq ($(WITH_LINEAGE_CHARGER),true)
     BOARD_HAL_STATIC_LIBRARIES := libhealthd.lineage


### PR DESCRIPTION
 * No longer needed, and is incomplete.

This reverts commit 1474aeb3c389389c430d536d00b0b117c83a2da9.

Change-Id: Iec1cf525651eb215fc9844b4340d57eb802aeeec