### PR TITLE
Split mobile and tv configs

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -13,11 +13,6 @@ PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
     ro.com.google.clientidbase=$(PRODUCT_GMS_CLIENTID_BASE)
 endif
 
-# Default notification/alarm sounds
-PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
-    ro.config.notification_sound=Argon.ogg \
-    ro.config.alarm_alert=Hassium.ogg
-
 ifeq ($(TARGET_BUILD_VARIANT),eng)
 # Disable ADB authentication
 PRODUCT_SYSTEM_DEFAULT_PROPERTIES += ro.adb.secure=0
@@ -127,40 +122,14 @@ PRODUCT_PACKAGES += \
 
 # AOSP packages
 PRODUCT_PACKAGES += \
-    Email \
-    ExactCalculator \
-    Exchange2 \
     Terminal
 
 # Lineage packages
 PRODUCT_PACKAGES += \
-    AudioFX \
-    Backgrounds \
     LineageParts \
     LineageSettingsProvider \
     LineageSetupWizard \
-    Eleven \
-    Jelly \
-    LockClock \
-    Profiles \
-    TrebuchetQuickStep \
-    Updater \
-    WeatherProvider
-
-# Accents
-PRODUCT_PACKAGES += \
-    LineageBlackTheme \
-    LineageDarkTheme \
-    LineageBlackAccent \
-    LineageBlueAccent \
-    LineageBrownAccent \
-    LineageCyanAccent \
-    LineageGreenAccent \
-    LineageOrangeAccent \
-    LineagePinkAccent \
-    LineagePurpleAccent \
-    LineageRedAccent \
-    LineageYellowAccent
+    Updater
 
 # Themes
 PRODUCT_PACKAGES += \
@@ -188,18 +157,6 @@ PRODUCT_PACKAGES += \
     wget \
     zip
 
-# Charger
-PRODUCT_PACKAGES += \
-    charger_res_images
-
-# Custom off-mode charger
-ifeq ($(WITH_LINEAGE_CHARGER),true)
-PRODUCT_PACKAGES += \
-    lineage_charger_res_images \
-    font_log.png \
-    libhealthd.lineage
-endif
-
 # Filesystems tools
 PRODUCT_PACKAGES += \
     fsck.exfat \
@@ -226,10 +183,6 @@ PRODUCT_PACKAGES += \
 # Storage manager
 PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
     ro.storage_manager.enabled=true
-
-# Media
-PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
-    media.recorder.show_manufacturer_and_model=true
 
 # These packages are excluded from user builds
 PRODUCT_PACKAGES_DEBUG += \

--- a/config/common_full.mk
+++ b/config/common_full.mk
@@ -1,5 +1,5 @@
 # Inherit common Lineage stuff
-$(call inherit-product, vendor/lineage/config/common.mk)
+$(call inherit-product, vendor/lineage/config/common_mobile.mk)
 
 PRODUCT_SIZE := full
 

--- a/config/common_full_tv.mk
+++ b/config/common_full_tv.mk
@@ -1,14 +1,4 @@
-# Exclude AudioFX
-TARGET_EXCLUDES_AUDIOFX := true
+# This config is for legacy purposes, there are no atv product size variants
 
-# Inherit full common Lineage stuff
-$(call inherit-product, vendor/lineage/config/common_full.mk)
-
-# Inherit Lineage atv device tree
-$(call inherit-product, device/lineage/atv/lineage_atv.mk)
-
-PRODUCT_PACKAGES += \
-    AppDrawer \
-    LineageCustomizer
-
-DEVICE_PACKAGE_OVERLAYS += vendor/lineage/overlay/tv
+# Inherit common atv Lineage stuff
+$(call inherit-product, vendor/lineage/config/common_tv.mk)

--- a/config/common_mini.mk
+++ b/config/common_mini.mk
@@ -1,4 +1,4 @@
 # Inherit mini common Lineage stuff
-$(call inherit-product, vendor/lineage/config/common.mk)
+$(call inherit-product, vendor/lineage/config/common_mobile.mk)
 
 PRODUCT_SIZE := mini

--- a/config/common_mini_tv.mk
+++ b/config/common_mini_tv.mk
@@ -1,5 +1,4 @@
-# Exclude AudioFX
-TARGET_EXCLUDES_AUDIOFX := true
+# This config is for legacy purposes, there are no atv product size variants
 
-# Inherit mini common Lineage stuff
-$(call inherit-product, vendor/lineage/config/common_mini.mk)
+# Inherit common atv Lineage stuff
+$(call inherit-product, vendor/lineage/config/common_tv.mk)

--- a/config/common_mobile.mk
+++ b/config/common_mobile.mk
@@ -1,0 +1,65 @@
+# Inherit common mobile Lineage stuff
+$(call inherit-product, vendor/lineage/config/common.mk)
+
+# Default notification/alarm sounds
+PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
+    ro.config.notification_sound=Argon.ogg \
+    ro.config.alarm_alert=Hassium.ogg
+
+ifneq ($(TARGET_BUILD_VARIANT),user)
+# Thank you, please drive thru!
+PRODUCT_SYSTEM_DEFAULT_PROPERTIES += persist.sys.dun.override=0
+endif
+
+# Optional packages
+PRODUCT_PACKAGES += \
+    LiveWallpapersPicker \
+    PhotoTable
+
+# AOSP packages
+PRODUCT_PACKAGES += \
+    Email \
+    ExactCalculator \
+    Exchange2
+
+# Lineage packages
+PRODUCT_PACKAGES += \
+    AudioFX \
+    Backgrounds \
+    Eleven \
+    Jelly \
+    LockClock \
+    Profiles \
+    TrebuchetQuickStep \
+    WeatherProvider
+
+# Accents
+PRODUCT_PACKAGES += \
+    LineageBlackTheme \
+    LineageDarkTheme \
+    LineageBlackAccent \
+    LineageBlueAccent \
+    LineageBrownAccent \
+    LineageCyanAccent \
+    LineageGreenAccent \
+    LineageOrangeAccent \
+    LineagePinkAccent \
+    LineagePurpleAccent \
+    LineageRedAccent \
+    LineageYellowAccent
+
+# Charger
+PRODUCT_PACKAGES += \
+    charger_res_images
+
+# Custom off-mode charger
+ifeq ($(WITH_LINEAGE_CHARGER),true)
+PRODUCT_PACKAGES += \
+    lineage_charger_res_images \
+    font_log.png \
+    libhealthd.lineage
+endif
+
+# Media
+PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
+    media.recorder.show_manufacturer_and_model=true

--- a/config/common_tv.mk
+++ b/config/common_tv.mk
@@ -1,0 +1,11 @@
+# Inherit common Lineage stuff
+$(call inherit-product, vendor/lineage/config/common.mk)
+
+# Inherit Lineage atv device tree
+$(call inherit-product, device/lineage/atv/lineage_atv.mk)
+
+PRODUCT_PACKAGES += \
+    AppDrawer \
+    LineageCustomizer
+
+DEVICE_PACKAGE_OVERLAYS += vendor/lineage/overlay/tv


### PR DESCRIPTION
There are a lot of apps installed by default that are unusable with
a controller. This splits the mobile related settings out of common
into a common_mobile config and adds common_tv.

Note: The EXCLUDE_AUDIOFX flag was removed from the tv configs
because the new config path no longer builds it.

Change-Id: I67db32750fca91725d703243f2bcee8bcd9b82cd