### PR TITLE
config: Move default alarm/notification/ringtone sound props to /product

### DIFF
--- a/config/common_mobile.mk
+++ b/config/common_mobile.mk
@@ -2,7 +2,7 @@
 $(call inherit-product, vendor/lineage/config/common.mk)
 
 # Default notification/alarm sounds
-PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
+PRODUCT_PRODUCT_PROPERTIES += \
     ro.config.notification_sound=Argon.ogg \
     ro.config.alarm_alert=Hassium.ogg
 

--- a/config/telephony.mk
+++ b/config/telephony.mk
@@ -13,7 +13,7 @@ PRODUCT_PACKAGES += \
     CellBroadcastReceiver
 
 # Default ringtone
-PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
+PRODUCT_PRODUCT_PROPERTIES += \
     ro.config.ringtone=Orion.ogg
 
 # Tethering - allow without requiring a provisioning app


### PR DESCRIPTION
* Allows us to override /vendor properties.

Change-Id: Iea344d347d8f10094f04cfb4a0bf1d4352fb667b