### PR TITLE
repopick: Use upstream instead of revision to determine branch

### DIFF
--- a/build/tools/repopick.py
+++ b/build/tools/repopick.py
@@ -253,7 +253,7 @@ if __name__ == '__main__':
         name = project.get('name')
         # when name and path are equal, "repo manifest" doesn't return a path at all, so fall back to name
         path = project.get('path', name)
-        revision = project.get('revision')
+        revision = project.get('upstream')
         if revision is None:
             for remote in remotes:
                 if remote.get('name') == project.get('remote'):


### PR DESCRIPTION
This is to allow repopick to determine a branch even on a
revision locked manifest. If upstream is not set, it falls
back to revision.

Per the repo manifest documentation:
Attribute upstream: Name of the Git ref in which a sha1 can be
found. Used when syncing a revision locked manifest in -c mode to
avoid having to sync the entire ref space. Project elements not
setting their own upstream will inherit this value.

Change-Id: I12876f7e3b440f9eab6d1b96eba9b18a13cff2e0