### PR TITLE
prebuilt: Clean up lineage-system.rc

### DIFF
--- a/prebuilt/common/etc/init/lineage-system.rc
+++ b/prebuilt/common/etc/init/lineage-system.rc
@@ -1,6 +1,5 @@
 # LineageOS core functionality
 on init
-    export ANDROID_CACHE /cache
     export TERMINFO /system/etc/terminfo
 
 on post-fs-data
@@ -9,10 +8,6 @@ on post-fs-data
     # Change permissions on fsck log so it can be added to the dropbox
     chown root log /dev/fscklogs/log
     chmod 0640 /dev/fscklogs/log
-
-on boot
-    # Persistent properties (only created if persist exists)
-    mkdir /persist/properties 0770 system system
 
 # bugreport is triggered by holding down volume down, volume up and power
 service bugreport /system/bin/dumpstate -d -p -B -z \


### PR DESCRIPTION
 * There is no reference to ANDROID_CACHE now, and
   /persist does not exist on most devices, neither
   can we write to it.

Change-Id: I91af1e6f571ced317d195e3a7901bf4c269486a1